### PR TITLE
support passing links on cmdline

### DIFF
--- a/pockyt/client.py
+++ b/pockyt/client.py
@@ -97,6 +97,10 @@ class Client(object):
                 else:
                     continue
 
+    def _get_args_input(self):
+        info = self._unformat_spec.parse(self._args.input.strip())
+        self._input.append(info)
+
     def _validate_format(self):
         # interpret escape sequences
         try:
@@ -239,6 +243,8 @@ class Client(object):
                 self._get_console_input()
             elif self._args.input == 'redirect':
                 self._get_redirect_input()
+            elif self._args.input.startswith('http'):
+                self._get_args_input()
             else:
                 self._get_file_input()
 

--- a/pockyt/pockyt.py
+++ b/pockyt/pockyt.py
@@ -96,7 +96,7 @@ class Pockyt(object):
         )
         put_parser.add_argument(
             '-i', '--input', default='console', metavar='<option>',
-            help='obtain input : <option> : {console, [redirect, filename]}',
+            help='obtain input : <option> : {console, [redirect, link, filename]}',
         )
 
         # modify items in collection


### PR DESCRIPTION
I've added a simple check to support passing links directly on the commandline. I use this in my emacs setup so i can add to pocket directly from emacs(and without sending data to process's standard input). I know this is quite hacky but it did the job for me!