### PR TITLE
Fix to wait until account connection is completed

### DIFF
--- a/pockyt/auth.py
+++ b/pockyt/auth.py
@@ -101,7 +101,7 @@ class Authenticator(object):
 
         Browser.open_new_tab(auth_link)
 
-        print('Step 3:\nConnect an account, via this link :\n` {0} `\n'
+        input('Step 3:\nConnect an account, via this link :\n` {0} `\n'
               'Press Enter to when done...'.format(auth_link))
 
         self._obtain_access_token()


### PR DESCRIPTION
Because pockyt doesn't wait for application connection in Step 3,
a user fails initial registration with errors. This commit changes
the authentication flow in Step 3 ("Connect an account") to wait
until the user presses Enter.