### PR TITLE
Displaying tags in "get" 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,7 @@ teardown:
 	rm -rf .venv
 
 test:
-	python tests.py 
+	python tests.py
+
+run:
+	@pockyt get -s unread -f '{title} | {tags}'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+all:
+
+setup:
+	@echo "setting up virtual environment"
+	virtualenv .venv
+	@echo "\nREADY! remember to run:\n source .venv/bin/activate\n\n"
+
+install:
+	python setup.py install
+
+teardown:
+	@echo "removing virtual environment"
+	rm -rf .venv
+
+test:
+	python tests.py 

--- a/pockyt/client.py
+++ b/pockyt/client.py
@@ -125,6 +125,7 @@ class Client(object):
         payload = {
             'state': self._args.state,
             'sort': self._args.sort,
+            #TODO: 'detailType': 'complete',
         }
 
         if self._args.content != 'all':
@@ -165,8 +166,14 @@ class Client(object):
             'title': item.get('resolved_title'),
             'link': item.get('resolved_url'),
             'excerpt': item.get('excerpt'),
-            'tags': item.get('tags'),
+            'tags': self._displayTags(item.get('tags')),
         } for item in items.values())
+
+    def _displayTags(self, item_tags):
+        """
+        item_tags will be either: None, or OrderedDictionary
+        """
+        return item_tags
 
     def _put(self):
         payload = {

--- a/pockyt/client.py
+++ b/pockyt/client.py
@@ -166,10 +166,10 @@ class Client(object):
             'title': item.get('resolved_title'),
             'link': item.get('resolved_url'),
             'excerpt': item.get('excerpt'),
-            'tags': self._displayTags(item.get('tags')),
+            'tags': self._process_tags(item.get('tags')),
         } for item in items.values())
 
-    def _displayTags(self, item_tags):
+    def _process_tags(self, item_tags):
         """
         item_tags will be either: None, or OrderedDictionary
         """

--- a/pockyt/client.py
+++ b/pockyt/client.py
@@ -125,7 +125,7 @@ class Client(object):
         payload = {
             'state': self._args.state,
             'sort': self._args.sort,
-            #TODO: 'detailType': 'complete',
+            'detailType': 'complete',
         }
 
         if self._args.content != 'all':
@@ -173,7 +173,7 @@ class Client(object):
         """
         item_tags will be either: None, or OrderedDictionary
         """
-        return item_tags
+        return sorted(item_tags.keys()) if item_tags else []
 
     def _put(self):
         payload = {

--- a/pockyt/client.py
+++ b/pockyt/client.py
@@ -173,7 +173,9 @@ class Client(object):
         """
         item_tags will be either: None, or OrderedDictionary
         """
-        return sorted(item_tags.keys()) if item_tags else []
+        keys = item_tags.keys() if item_tags else []
+        keys = [str(t) for t in keys]
+        return sorted(keys)
 
     def _put(self):
         payload = {

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,20 @@
+import unittest
+
+class TestStringMethods(unittest.TestCase):
+
+    def test_upper(self):
+        self.assertEqual('foo'.upper(), 'FOO')
+
+    def test_isupper(self):
+        self.assertTrue('FOO'.isupper())
+        self.assertFalse('Foo'.isupper())
+
+    def test_split(self):
+        s = 'hello world'
+        self.assertEqual(s.split(), ['hello', 'world'])
+        # check that s.split fails when the separator is not a string
+        with self.assertRaises(TypeError):
+            s.split(2)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -9,15 +9,15 @@ class TestStringMethods(unittest.TestCase):
         self._client = Client(None, None)
 
     def test_returns_tags_as_sorted_list(self):
-        tags = self._client._displayTags(self.newTagDictionary())
+        tags = self._client._process_tags(self.newTagDictionary())
         self.assertEqual(tags, ['tag1', 'tag2', 'tag3'])
 
     def test_returns_empty_list_when_there_are_no_tags(self):
-        tags = self._client._displayTags(None)
+        tags = self._client._process_tags(None)
         self.assertEqual(tags, [])
 
     def test_returned_tags_are_all_ascii_strings(self):
-        tags = self._client._displayTags(self.newTagDictionary())
+        tags = self._client._process_tags(self.newTagDictionary())
 
         non_string_tags = [t for t in tags if not isinstance(t, str)]
         self.assertEqual(non_string_tags, [])

--- a/tests.py
+++ b/tests.py
@@ -1,20 +1,13 @@
 import unittest
 
+from pockyt.client import Client
+
 class TestStringMethods(unittest.TestCase):
 
-    def test_upper(self):
-        self.assertEqual('foo'.upper(), 'FOO')
-
-    def test_isupper(self):
-        self.assertTrue('FOO'.isupper())
-        self.assertFalse('Foo'.isupper())
-
-    def test_split(self):
-        s = 'hello world'
-        self.assertEqual(s.split(), ['hello', 'world'])
-        # check that s.split fails when the separator is not a string
-        with self.assertRaises(TypeError):
-            s.split(2)
+    def test_pockyt(self):
+        c = Client(None, None)
+        tags = c._displayTags('tags')
+        self.assertEqual(tags, 'tags')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -16,11 +16,17 @@ class TestStringMethods(unittest.TestCase):
         tags = self._client._displayTags(None)
         self.assertEqual(tags, [])
 
+    def test_returned_tags_are_all_ascii_strings(self):
+        tags = self._client._displayTags(self.newTagDictionary())
+
+        non_string_tags = [t for t in tags if not isinstance(t, str)]
+        self.assertEqual(non_string_tags, [])
+
     def newTagDictionary(self):
         d = {
-        "tag1": "object B",
+        u"tag1": "object B",
         "tag2": "object A",
-        "tag3": "object Z",
+        u"tag3": "object Z",
         }
         return collections.OrderedDict(sorted(d.items(), key=lambda x:x[1]))
 

--- a/tests.py
+++ b/tests.py
@@ -1,13 +1,28 @@
 import unittest
+import collections
 
 from pockyt.client import Client
 
 class TestStringMethods(unittest.TestCase):
 
-    def test_pockyt(self):
-        c = Client(None, None)
-        tags = c._displayTags('tags')
-        self.assertEqual(tags, 'tags')
+    def setUp(self):
+        self._client = Client(None, None)
+
+    def test_returns_tags_as_sorted_list(self):
+        tags = self._client._displayTags(self.newTagDictionary())
+        self.assertEqual(tags, ['tag1', 'tag2', 'tag3'])
+
+    def test_returns_empty_list_when_there_are_no_tags(self):
+        tags = self._client._displayTags(None)
+        self.assertEqual(tags, [])
+
+    def newTagDictionary(self):
+        d = {
+        "tag1": "object B",
+        "tag2": "object A",
+        "tag3": "object Z",
+        }
+        return collections.OrderedDict(sorted(d.items(), key=lambda x:x[1]))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I found that the "get" function wasn't displaying the tags associated with each entry. I implemented a fix. Also added some basic build script (using Make) and some unit tests for the change.